### PR TITLE
adding an -npad option to discard padded dupes

### DIFF
--- a/butterflow/cli.py
+++ b/butterflow/cli.py
@@ -75,6 +75,10 @@ def main():
                      '(default: %(default)s)')
     vid.add_argument('-l', '--lossless', action='store_true',
                      help='Set to use lossless encoding settings')
+    vid.add_argument('-npad', '--no-padding', action='store_false',
+                     help='Set to discard duplicate frames that are padded to '
+                     'the end of subregions. This will alter the expected '
+                     'duration of the output video.')
     vid.add_argument('-dt', '--detelecine', action='store_true',
                      help='Set to do a basic inverse telecine on the input '
                      'video')
@@ -225,6 +229,7 @@ def main():
         args.add_info,
         args.text_type,
         args.mux,
+        args.no_padding,
         settings.default['av_loglevel'],
         settings.default['enc_loglevel'],
         flow_kwargs)

--- a/butterflow/render.py
+++ b/butterflow/render.py
@@ -21,14 +21,14 @@ log = logging.getLogger('butterflow')
 
 class Renderer(object):
     def __init__(
-            self, dst_path, video_info, video_sequence, playback_rate,
-            flow_func=settings['flow_func'],
-            interpolate_func=settings['interpolate_func'],
-            scale=settings['video_scale'], detelecine=False, grayscale=False,
-            lossless=False, trim=False, show_preview=True, add_info=False,
-            text_type=settings['text_type'], mux=False,
-            av_loglevel=settings['av_loglevel'],
-            enc_loglevel=settings['enc_loglevel'], flow_kwargs=None):
+        self, dst_path, video_info, video_sequence, playback_rate,
+        flow_func=settings['flow_func'],
+        interpolate_func=settings['interpolate_func'],
+        scale=settings['video_scale'], detelecine=False, grayscale=False,
+        lossless=False, trim=False, show_preview=True, add_info=False,
+        text_type=settings['text_type'], mux=False, pad_with_dupes=True,
+        av_loglevel=settings['av_loglevel'],
+        enc_loglevel=settings['enc_loglevel'], flow_kwargs=None):
         self.dst_path = dst_path
         self.video_info = video_info
         self.video_sequence = video_sequence
@@ -38,7 +38,7 @@ class Renderer(object):
         self.text_type = text_type
         self.add_info = add_info
         self.mux = mux
-        self.av_loglevel = av_loglevel
+        self.pad_with_dupes = pad_with_dupes
         self.enc_loglevel = enc_loglevel
         self.playback_rate = float(playback_rate)
         self.scale = scale
@@ -417,6 +417,8 @@ class Renderer(object):
                 if fin_run:
                     wrts_needed = (tgt_frs - frs_wrt)
                     fin_dup = wrts_needed - 1
+                    if not self.pad_with_dupes:
+                        wrts_needed = 0
                 for z in range(wrts_needed):
                     frs_wrt += 1
                     self.total_frs_wrt += 1

--- a/butterflow/render.py
+++ b/butterflow/render.py
@@ -39,6 +39,7 @@ class Renderer(object):
         self.add_info = add_info
         self.mux = mux
         self.pad_with_dupes = pad_with_dupes
+        self.av_loglevel = av_loglevel
         self.enc_loglevel = enc_loglevel
         self.playback_rate = float(playback_rate)
         self.scale = scale
@@ -282,6 +283,8 @@ class Renderer(object):
         if mak_fac == 0:
             tgt_frs = 1
             mak_fac = 1
+        import pdb; pdb.set_trace()
+
         time_step = min(1.0, 1 / mak_fac)
 
         # if 1.0 % time_step is zero, one less frame will be

--- a/butterflow/render.py
+++ b/butterflow/render.py
@@ -418,7 +418,8 @@ class Renderer(object):
                     wrts_needed = (tgt_frs - frs_wrt)
                     fin_dup = wrts_needed - 1
                     if not self.pad_with_dupes:
-                        wrts_needed = 0
+                        if fin_dup > 0:
+                            wrts_needed = 1
                 for z in range(wrts_needed):
                     frs_wrt += 1
                     self.total_frs_wrt += 1

--- a/butterflow/settings.py
+++ b/butterflow/settings.py
@@ -39,6 +39,8 @@ default = {
     'flow_filter':    'box',
     # -1 is max threads and it's the opencv default
     'ocv_threads':    1*-1,
+    # milliseconds to display image in preview window
+    'imshow_ms':      1,
     # debugging info font options
     'text_type':      'light',
     'light_color':    cv2.cv.RGB(255, 255, 255),


### PR DESCRIPTION
This commit adds the `-npad, --no-padding` option to discard duplicate frames that are padded at the end of video segments. This is useful for creating smoother transitions between subregions at the expense of having a video with an unexpected duration.